### PR TITLE
Fix middleware list invocation through settings

### DIFF
--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -110,7 +110,10 @@ class Form(forms.BaseForm):
         settings["SITE_ID"] = SiteID(default=int(env("SITE_ID", 1)))
         settings["INSTALLED_APPS"].append("multisite")
 
-        MIDDLEWARE_CLASSES = settings["MIDDLEWARE_CLASSES"]
+        MIDDLEWARE_CLASSES = settings.get(
+            # Django used MIDDLEWARE_CLASSES prior to version 2.0
+            "MIDDLEWARE", settings.get("MIDDLEWARE_CLASSES")
+        )
 
         # multisite.middleware.DynamicSiteMiddleware must be before
         # cms.middleware.utils.ApphookReloadMiddleware


### PR DESCRIPTION
Django used to include middleware classes in settings within a list called MIDDLEWARE_CLASSES prior to version 2.0 and MIDDLEWARE afterwards. This is a fix to address both cases.